### PR TITLE
コントリビュータのアイコンと名前、役割の表示

### DIFF
--- a/components/ContributorCard.vue
+++ b/components/ContributorCard.vue
@@ -32,12 +32,12 @@ export default {
   display: inline-block;
   width: 100px;
   height: 145px;
-}
-.ContriCard img {
-  object-fit: cover;
-  border-radius: 50%;
-  border: 1px solid #f3f3f4;
-  box-sizing: border-box;
+  > img {
+    object-fit: cover;
+    border-radius: 50%;
+    border: 1px solid #f3f3f4;
+    box-sizing: border-box;
+  }
 }
 .ContriText {
   width: 100%;

--- a/components/ContributorCard.vue
+++ b/components/ContributorCard.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-card flat class="ContriCard">
+    <v-avatar size="100px">
+      <img :src="iconPath" />
+    </v-avatar>
+    <span class="ContriText ContriName">{{ name }}</span>
+    <span class="ContriText ContriRole">{{ role }}</span>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    iconPath: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      required: true
+    },
+    role: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.ContriCard {
+  display: inline-block;
+  width: 100px;
+  height: 145px;
+}
+.ContriCard img {
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid #f3f3f4;
+  box-sizing: border-box;
+}
+.ContriText {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  letter-spacing: 0.03em;
+  line-height: 180%;
+}
+.ContriName {
+  margin-top: 4px;
+  font-weight: bold;
+  font-size: 15px;
+}
+.ContriRole {
+  font-weight: normal;
+  font-size: 11px;
+}
+</style>


### PR DESCRIPTION
close #9 

v-avatarだと画像の縦横比が変わってしまうため

```css
object-fit: cover;
```
をimgタグに適用してトリミングするようにしました。

Figmaで横並びでコントリビューターが並んでいたためinline-blockで横並びにできるようにしました。
![image](https://user-images.githubusercontent.com/51294895/84470325-12f48580-acbe-11ea-9880-d8f413b0ebd8.png)
