### PR TITLE
overflow:hiddenを追加

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -223,6 +223,7 @@ export default {
 
   font-style: normal;
   font-weight: bold;
+  overflow: hidden;
 
   .Title {
     .MainTitle {


### PR DESCRIPTION
indexページでコンテンツ幅をはみだす問題を修正。
一番簡単な方法で対応しました。

![スクリーンショット 2020-06-16 16 04 01](https://user-images.githubusercontent.com/14883063/84742144-04bea600-afeb-11ea-9d57-5eb92cf73357.png)
