### PR TITLE
セクションタイトルのマークアップとcssを修正

### DIFF
--- a/components/BackTemplate.vue
+++ b/components/BackTemplate.vue
@@ -1,12 +1,12 @@
 <template>
-  <div :class="[backIsGray ? 'GrayBackGround' : 'WhiteBackGround']">
-    <p v-if="subTitle" class="SubTitle">{{ subTitle }}</p>
-    <p :class="[subTitle ? 'MainTitle' : 'MainTitle-NoSubTitle']">
-      {{ title }}
-    </p>
+  <section :class="[backIsGray ? 'GrayBackGround' : 'WhiteBackGround']">
+    <header>
+      <span v-if="subTitle" class="SubTitle">{{ subTitle }}</span>
+      <h2 class="MainTitle">{{ title }}</h2>
+    </header>
     <p v-if="desc" class="Desc">{{ desc }}</p>
     <slot name="contents" />
-  </div>
+  </section>
 </template>
 
 <script>
@@ -43,21 +43,14 @@ export default {
   color: $base-gray;
   text-align: center;
 
-  .MainTitle,
-  .MainTitle-NoSubTitle {
+  .MainTitle {
     font-weight: bold;
     font-size: 22px;
     letter-spacing: 0.03em;
-    white-space: pre-wrap;
-    margin-top: -10px;
-    margin-bottom: 0;
+    padding: 10px 0 25px;
     @include largerThan($small) {
       font-size: 25px;
     }
-  }
-
-  .MainTitle-NoSubTitle {
-    margin-top: 50px;
   }
 
   .SubTitle {
@@ -65,7 +58,6 @@ export default {
     font-weight: bold;
     font-size: 15px;
     letter-spacing: 0.03em;
-    margin-bottom: -30px;
   }
 
   .Desc {


### PR DESCRIPTION
close #122 

- マークアップを修正しました。
- `white-space: pre-wrap;` で先頭がずれるので、paddingで整えるように修正しました。

<img width="1081" alt="スクリーンショット 2020-10-13 11 58 50" src="https://user-images.githubusercontent.com/14883063/95810740-a90fe980-0d4c-11eb-948e-1613c985c3f3.png">
